### PR TITLE
Add check if src/dst default or none

### DIFF
--- a/scripts/fmain.py
+++ b/scripts/fmain.py
@@ -2,9 +2,25 @@ import os
 import shutil
 import PySimpleGUI as sg
 
-source_folder = sg.popup_get_folder('Choose source location:', default_path='')
+source_folder = sg.popup_get_folder('Choose source location:', default_path="Source Directory Path...")
+if source_folder == "Source Directory Path...":
+    sg.PopupError("Directory path not specified!")
+    raise SystemExit()
+elif source_folder is None:
+    raise SystemExit()
+else:
+    pass
+
 destination_folder = sg.popup_get_folder(
-    'Choose destination folder:', default_path='')
+    'Choose destination folder:', default_path="Destination Directory Path...")
+
+if destination_folder == "Destination Directory Path...":
+    sg.PopupError("Directory path not specified!")
+    raise SystemExit()
+elif destination_folder is None:
+    raise SystemExit()
+else:
+    pass
 
 file_type = []
 mode_list = []


### PR DESCRIPTION
# Description

I've created a simple fix that checks whether source and/or destination directories are specified when prompted to select them. If none are specified (the placeholder text remains) or if 'Cancel' button is pressed, the program is terminated.

## Fixes #14

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines ([PEP 8](https://pep8.org/)) of this project.
- [X] I have performed a self-review of my own code and have established there are no errors.
- [X] My changes generate no new warnings.
